### PR TITLE
Fix a problem with fundeps on GHC 7.2

### DIFF
--- a/Data/AttoLisp.hs
+++ b/Data/AttoLisp.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings, Rank2Types, DeriveDataTypeable, BangPatterns #-}
 -- The following is for the ParseList stuff
 {-# LANGUAGE MultiParamTypeClasses, FunctionalDependencies, FlexibleInstances,
-             UndecidableInstances #-}
+             UndecidableInstances, ScopedTypeVariables, OverlappingInstances, EmptyDataDecls #-}
 -- | Efficient parsing and serialisation of S-Expressions (as used by Lisp).
 --
 -- This module is intended to be imported qualified, e.g.:
@@ -305,15 +305,48 @@ typeMismatch expected actual =
 class ParseList a b | a -> b where
   parseList :: String -> a -> [Lisp] -> Parser b
 
-instance (FromLisp a, ParseList b c) => ParseList (a -> b) c where
-  parseList msg _ []     = fail $ "Too few arguments for object: " ++ msg
-  parseList msg f (x:xs) = do
+instance (IsFunction a f, ParseList' f a b) => ParseList a b where
+  parseList = parseList' (undefined :: f)
+
+class ParseList' f a b | f a -> b where
+  parseList' :: f -> String -> a -> [Lisp] -> Parser b
+
+instance (FromLisp a, IsFunction b f, ParseList' f b c, ParseList b c)
+  => ParseList' HTrue (a -> b) c where
+  parseList' _ msg _ []     = fail $ "Too few arguments for object: " ++ msg
+  parseList' _ msg f (x:xs) = do
     y <- parseLisp x
     parseList msg (f y) xs
 
-instance ParseList a a where
-  parseList _msg r [] = return r
-  parseList msg  _ (_:_) = fail $ "Too many arguments for object: " ++ msg
+instance ParseList' HFalse a a where
+  parseList' _ _msg r [] = return r
+  parseList' _ msg  _ (_:_) = fail $ "Too many arguments for object: " ++ msg
+
+data HTrue
+data HFalse
+
+class IsFunction a b | a -> b
+
+instance TypeCast f HTrue => IsFunction (x -> y) f
+instance TypeCast f HFalse => IsFunction a f
+
+class TypeCast a b | a -> b, b -> a where
+  typeCast :: a -> b
+
+class TypeCast' t a b | t a -> b, t b -> a where
+  typeCast' :: t -> a -> b
+
+class TypeCast'' t a b | t a -> b, t b -> a where
+  typeCast'' :: t -> a -> b
+
+instance TypeCast' () a b => TypeCast a b where
+  typeCast x = typeCast' () x
+
+instance TypeCast'' t a b => TypeCast' t a b where
+  typeCast' = typeCast''
+
+instance TypeCast'' () a a where
+  typeCast'' _ x  = x
 
 -- | Decode structure serialised with 'mkStruct'.
 --


### PR DESCRIPTION
Introduced `IsFunction` type class, which was quoted from http://okmij.org/ftp/Haskell/typecast.html#is-function-type.

The problem is that we cannot compile `Data.AttoLisp.Test` with GHC 7.2.1:

```
maoe@maoe.local
% ghc Data/AttoLisp/Test.hs                         /Users/maoe/coding/haskell/atto-lisp
[1 of 2] Compiling Data.AttoLisp    ( Data/AttoLisp.hs, Data/AttoLisp.o )
[2 of 2] Compiling Data.AttoLisp.Test ( Data/AttoLisp/Test.hs, Data/AttoLisp/Test.o )

Data/AttoLisp/Test.hs:24:17:
    Couldn't match type `T.Text -> Integer -> Msg' with `Msg'
    When using functional dependencies to combine
      Data.AttoLisp.ParseList a a,
        arising from the dependency `a -> b'
        in the instance declaration at Data/AttoLisp.hs:314:10
      Data.AttoLisp.ParseList (T.Text -> Integer -> Msg) Msg,
        arising from a use of `struct' at Data/AttoLisp/Test.hs:24:17-22
    In the expression: struct "msg" Msg e
    In an equation for `parseLisp': parseLisp e = struct "msg" Msg e
```
