### PR TITLE
Update libraries dependencies to work with latest versions

### DIFF
--- a/Data/AttoLisp.hs
+++ b/Data/AttoLisp.hs
@@ -687,7 +687,7 @@ skipLispSpace = skipSpace >> optional comment >> skipSpace
 
 comment :: A.Parser ()
 comment = do
-  _ <- char ';' >> A.many (notChar '\n')
+  _ <- char ';' >> Control.Applicative.many (notChar '\n')
   end <- atEnd
   if end then char '\n' >> return () else return ()
 

--- a/atto-lisp.cabal
+++ b/atto-lisp.cabal
@@ -15,7 +15,7 @@ cabal-version:          >= 1.6
 
 library
   build-depends:
-    attoparsec    >= 0.8.5.1 && < 0.10,
+    attoparsec    >= 0.8.5.1 && < 0.11,
     base          >= 4.2     && < 5,
     blaze-builder >= 0.3     && < 0.4,
     blaze-textual >= 0.1     && < 0.3,


### PR DESCRIPTION
The deepseq-1.3 support is necessary to support the upcoming GHC-7.4 release
