### PR TITLE
Any lisp expression can be quoted

### DIFF
--- a/Data/AttoLisp.hs
+++ b/Data/AttoLisp.hs
@@ -661,7 +661,7 @@ like a number then it is one.  Otherwise it's just a symbol.
 lisp :: A.Parser Lisp
 lisp = skipLispSpace *>
   (AC.char '(' *> list_ <|>
-   quoted <$> (AC.char '\'' *> AC.char '(' *> list_) <|>
+   quoted <$> (AC.char '\'' *> lisp) <|>
    String <$> (AC.char '"' *> lstring_) <|>
    atom)
  where

--- a/atto-lisp.cabal
+++ b/atto-lisp.cabal
@@ -1,5 +1,5 @@
 name:                   atto-lisp
-version:                0.2.2.3
+version:                0.2.2.4
 license:                BSD3
 license-file:           LICENSE
 author:                 Thomas Schilling <nominolo@googlemail.com>

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+0.2.2.4
+
+ * Any lisp expression can be quoted.
+
 0.2.2.2
 
  * Allow attoparsec-0.13


### PR DESCRIPTION
Lisp syntax allows you to quote not just lists.  This is valid lisp:

'my-symbol

however the parser currently only supports lists.